### PR TITLE
Observers sub-key not used in the UFO filter test

### DIFF
--- a/src/jcb/driver.py
+++ b/src/jcb/driver.py
@@ -23,7 +23,7 @@ def jcb_driver():
 
       or
 
-      jcb render -i dictionary_of_templates.yaml -o jedi_dict.yaml
+      jcb render dictionary_of_templates.yaml jedi_dict.yaml
 
     """
     pass

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -218,7 +218,7 @@ class Renderer():
             observers = get_nested_dict(jedi_dict, observer_location)
 
             # Loop over the observers and remove the non allowable components
-            for observer in observers['observers']:
+            for observer in observers:
 
                 observer_keys = observer.keys()
 


### PR DESCRIPTION
The UFO filter test yaml is different from the other in the sense that the observers list is not nested as:

```yaml
observations:
  observers:
  - yaml
  - yaml
```

and is instead 

```yaml
observations:
- yaml
- yaml
```