### PR TITLE
Remove png's/LFS 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.png filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -1,23 +1,4 @@
-<div
-  align="center"
->
-
-<img
-  style="vertical-align:middle"
-  src="https://github.com/danholdaway/jcb/blob/develop/etc/jcb.png"
-  width="30%"
-  alt="JEDI Configuration Builder"
-/>
-
-<img
-  style="vertical-align:middle"
-  src="https://github.com/danholdaway/jcb/blob/develop/etc/jcb-text.png"
-  width="40%"
-  alt="JEDI Configuration Builder"
-/>
-</div>
-
-#
+# JEDI Configuration Builder
 
 ### Repository status:
 

--- a/etc/jcb-text.png
+++ b/etc/jcb-text.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fdb18ddd36bb2285c6e588ad94559babc318eba3e802b9e1c349fed18a3a82af
-size 10699

--- a/etc/jcb.png
+++ b/etc/jcb.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8ea938261809c6a206a856297c7e242edc396169ec8ca2102a7987db04656696
-size 145481


### PR DESCRIPTION
What the title says. We currently cannot clone develop or the commit that the gdasapp uses:

![jcb-error](https://github.com/user-attachments/assets/cbd83bef-16e6-47f8-a775-36043b438795)

Cloning this branch works:
```console
git clone --branch feature/ciao-lfs https://github.com/NOAA-EMC/jcb.git
Cloning into 'jcb'...
remote: Enumerating objects: 659, done.
remote: Counting objects: 100% (21/21), done.
remote: Compressing objects: 100% (21/21), done.
remote: Total 659 (delta 0), reused 1 (delta 0), pack-reused 638
Receiving objects: 100% (659/659), 121.50 KiB | 5.28 MiB/s, done.
Resolving deltas: 100% (286/286), done.
```