### PR TITLE
Fix erroneous use of sys.exit in renderer

### DIFF
--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -2,7 +2,6 @@
 
 
 import os
-import sys
 
 import jcb
 import jinja2 as j2

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -194,7 +194,7 @@ class Renderer():
             jedi_dict_yaml = template.render(self.template_dict)
         except j2.exceptions.UndefinedError as e:
             print(f'Resolving templates for {algorithm} failed with the following exception: {e}')
-            sys.exit(1)
+            return None
 
         # Check that everything was rendered
         jcb.abort_if('{{' in jedi_dict_yaml, f'In template_string_jinja2 '

--- a/src/jcb/utilities/testing.py
+++ b/src/jcb/utilities/testing.py
@@ -60,6 +60,10 @@ def render_app_with_test_config(app_test_config):
     # --------------------------------
     jedi_dict_1 = jcb.render(app_test_config)
 
+    # Assert that the output is a dictionary
+    # --------------------------------------
+    assert isinstance(jedi_dict_1, dict)
+
     # Style 2 for call: renderer for multiple algorithms
     # --------------------------------------------------
     # Algorithm does not need to be in the dictionary of templates
@@ -68,6 +72,10 @@ def render_app_with_test_config(app_test_config):
 
     jcb_obj = jcb.Renderer(app_test_config)
     jedi_dict_2 = jcb_obj.render(algorithm)
+
+    # Assert that the output is a dictionary
+    # --------------------------------------
+    assert isinstance(jedi_dict_2, dict)
 
     # Assert that the two outputs match one another
     assert jedi_dict_1 == jedi_dict_2

--- a/test/client_integration/gdas-atmosphere-templates.yaml
+++ b/test/client_integration/gdas-atmosphere-templates.yaml
@@ -50,7 +50,12 @@ atmosphere_fv3jedi_files_path: DATA/fv3jedi
 atmosphere_background_path: DATA/bkg
 atmosphere_background_ensemble_path: "DATA/ens/mem%mem%"
 
+atmosphere_variational_history_prefix: "bkg_"
+atmosphere_ensemble_history_prefix: "ens_"
+
 atmosphere_background_time_iso: '2024-02-02T00:00:00Z'
+
+
 
 # Background error
 

--- a/test/client_integration/gdas-atmosphere-templates.yaml
+++ b/test/client_integration/gdas-atmosphere-templates.yaml
@@ -55,8 +55,6 @@ atmosphere_ensemble_history_prefix: "ens_"
 
 atmosphere_background_time_iso: '2024-02-02T00:00:00Z'
 
-
-
 # Background error
 
 atmosphere_bump_data_directory: DATA/berror

--- a/test/client_integration/test_client_calls.py
+++ b/test/client_integration/test_client_calls.py
@@ -28,7 +28,6 @@ def test_jcb():
     # ----------------------------------------------------------------------
     # Loop over apps
     for app in apps:
-
         path = os.path.join(os.path.dirname(__file__), f'{app}-*-templates.yaml')
         app_model_configs = glob.glob(path)
 

--- a/test/client_integration/test_client_calls.py
+++ b/test/client_integration/test_client_calls.py
@@ -28,6 +28,7 @@ def test_jcb():
     # ----------------------------------------------------------------------
     # Loop over apps
     for app in apps:
+
         path = os.path.join(os.path.dirname(__file__), f'{app}-*-templates.yaml')
         app_model_configs = glob.glob(path)
 


### PR DESCRIPTION
There was a use of sys.exit in the renderer. Since the testing calls this function using threading this is not safe since it causes the code to simply hang instead of throwing the actual exception. 

A PR in jcb-gdas caused the testing to break but rather than seeing the issue, the testing would simply hang.

PR puts in the missing template in place and protects against the same issue happening in the future.