### PR TITLE
Add ensemble mode to JCB

### DIFF
--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -216,7 +216,7 @@ class Renderer():
             try:
                 jedi_dict_yaml = template.render(template_dict_rendered)
             except j2.exceptions.UndefinedError as e:
-                print(f'Resolving templates for {algorithm} failed with the following exception: {e}')
+                print(f'Resolving templates for {algorithm} failed with exception: {e}')
                 return None
 
             # Check that everything was rendered

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -3,7 +3,6 @@
 
 import os
 
-import copy
 import jcb
 import jinja2 as j2
 import yaml

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -3,6 +3,7 @@
 
 import os
 
+import copy
 import jcb
 import jinja2 as j2
 import yaml
@@ -53,6 +54,11 @@ class Renderer():
 
         # Keep the dictionary of templates around
         self.template_dict = template_dict
+
+        # Optionally get the number of members (for ensemble based algorithms)
+        # --------------------------------------------------------------------
+        self.num_members = self.template_dict.get('number_ensemble_members', 1)
+        self.frst_member = self.template_dict.get('number_first_member', 1)
 
         # Set the paths where jinja will look for files in the hierarchy
         # --------------------------------------------------------------
@@ -188,52 +194,77 @@ class Renderer():
         # Make sure algorithm is in the template dictionary
         self.template_dict['algorithm'] = algorithm
 
-        # Render the template hierarchy
-        try:
-            jedi_dict_yaml = template.render(self.template_dict)
-        except j2.exceptions.UndefinedError as e:
-            print(f'Resolving templates for {algorithm} failed with the following exception: {e}')
-            return None
+        # List of JEDI dictionaries for each member
+        jedi_dicts = {'members': []}
 
-        # Check that everything was rendered
-        jcb.abort_if('{{' in jedi_dict_yaml, f'In template_string_jinja2 '
-                     f'the output string still contains template directives. '
-                     f'{jedi_dict_yaml}')
+        # Loop over the members
+        for member in range(self.num_members):
 
-        jcb.abort_if('}}' in jedi_dict_yaml, f'In template_string_jinja2 '
-                     f'the output string still contains template directives. '
-                     f'{jedi_dict_yaml}')
+            # Convert template dictionary to string (YAML)
+            template_dict_str = yaml.dump(self.template_dict)
 
-        # print(' ')
+            # Dictionary containing just member number
+            member_dict = {'member': member + self.frst_member}
 
-        # Convert string form of the dictionary to a dictionary
-        jedi_dict = yaml.safe_load(jedi_dict_yaml)
+            # Run jinja2 on template_dict_str to complete {{member}} template
+            template_dict_str = j2.Template(template_dict_str).render(member_dict)
 
-        # Clean up the observers part of the dictionary if necessary. Should only have the
-        # components that the algorithm allows for.
-        # --------------------------------------------------------------------------------
-        if algorithm in self.observer_components:
-            # Get the observer components for this algorithm
-            observer_location = self.observer_components[algorithm]['observer_nesting']
-            allowable_keys = self.observer_components[algorithm]['components']
+            # Convert back to dictionary
+            template_dict_rendered = yaml.safe_load(template_dict_str)
 
-            # Pointer to observers (mutable list so should not copy here)
-            observers = get_nested_dict(jedi_dict, observer_location)
+            # Render the template hierarchy
+            try:
+                jedi_dict_yaml = template.render(template_dict_rendered)
+            except j2.exceptions.UndefinedError as e:
+                print(f'Resolving templates for {algorithm} failed with the following exception: {e}')
+                return None
 
-            # Loop over the observers and remove the non allowable components
-            for observer in observers:
+            # Check that everything was rendered
+            jcb.abort_if('{{' in jedi_dict_yaml, f'In template_string_jinja2 '
+                         f'the output string still contains template directives. '
+                         f'{jedi_dict_yaml}')
 
-                observer_keys = observer.keys()
+            jcb.abort_if('}}' in jedi_dict_yaml, f'In template_string_jinja2 '
+                         f'the output string still contains template directives. '
+                         f'{jedi_dict_yaml}')
 
-                # Find the observer components that are not allowable
-                keys_to_remove = [key for key in observer_keys if key not in allowable_keys]
+            # print(' ')
 
-                # Remove the non allowable components
-                for key in keys_to_remove:
-                    del observer[key]
+            # Convert string form of the dictionary to a dictionary
+            jedi_dict = yaml.safe_load(jedi_dict_yaml)
 
-        # Convert the rendered string to a dictionary
-        return jedi_dict
+            # Clean up the observers part of the dictionary if necessary. Should only have the
+            # components that the algorithm allows for.
+            # --------------------------------------------------------------------------------
+            if algorithm in self.observer_components:
+                # Get the observer components for this algorithm
+                observer_location = self.observer_components[algorithm]['observer_nesting']
+                allowable_keys = self.observer_components[algorithm]['components']
+
+                # Pointer to observers (mutable list so should not copy here)
+                observers = get_nested_dict(jedi_dict, observer_location)
+
+                # Loop over the observers and remove the non allowable components
+                for observer in observers:
+
+                    observer_keys = observer.keys()
+
+                    # Find the observer components that are not allowable
+                    keys_to_remove = [key for key in observer_keys if key not in allowable_keys]
+
+                    # Remove the non allowable components
+                    for key in keys_to_remove:
+                        del observer[key]
+
+            # Add to the list
+            jedi_dicts['members'].append(jedi_dict)
+
+        # If there is only one member return the first element of the list
+        # otherwise return the ensemble application ready dictionary
+        if self.num_members == 1:
+            return jedi_dicts['members'][0]
+        else:
+            return jedi_dicts
 
 
 # --------------------------------------------------------------------------------------------------

--- a/test/client_integration/test_client_calls.py
+++ b/test/client_integration/test_client_calls.py
@@ -28,18 +28,23 @@ def test_jcb():
     # ----------------------------------------------------------------------
     # Loop over apps
     for app in apps:
-        path = os.path.join(os.path.dirname(__file__), f'{app}-*-templates.yaml')
+        path = os.path.join(os.path.dirname(__file__), f'{app}-*.yaml')
         app_model_configs = glob.glob(path)
 
         # Loop over the configs, open and add for each supported_algorithm
         for app_model_config in app_model_configs:
 
+            print(f'Processing {app_model_config}')
+
             with open(app_model_config, 'r') as f:
                 dictionary_of_templates = yaml.safe_load(f)
 
             # Extract the supported_algorithms key and then remove that key from the dictionary
-            supported_algorithms = dictionary_of_templates['supported_algorithms']
-            del dictionary_of_templates['supported_algorithms']
+            if 'supported_algorithms' not in dictionary_of_templates:
+                supported_algorithms = [dictionary_of_templates['algorithm']]
+            else:
+                supported_algorithms = dictionary_of_templates['supported_algorithms']
+                del dictionary_of_templates['supported_algorithms']
 
             # Loop over the supported_algorithms
             for supported_algorithm in supported_algorithms:


### PR DESCRIPTION
Add ensemble mode to JCB. Now jcb-base.yaml files can contain two new keys: 

``` YAML
number_ensemble_members: 2   # Number of ensemble members (default is 1)
number_first_member: 0       # Index for first member (default is 1)
```

And later on contain templates (within jcb-base) like:

``` YAML
snow_background_path: Data/member{{ "%0{}d".format(3)|format(member) }}/
```

The resulting YAML will look like:

``` YAML
members
- <all configuration for member 000>
- <all configuration for member 001>
```

If `number_ensemble_members` is 1 or not present the YAML will look like it did before.

An OOPS change is in progress to allow ensemble applications with YAMLs of this form (in addition to passing a YAML with a list of files in it)
