### PR TITLE
add missing thing to renderer for conventional reject list

### DIFF
--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -166,6 +166,9 @@ class Renderer():
                 # Add global functions for retrieving the satellite channel dependant variables
                 self.env.globals['get_satellite_variable'] = self.obs_chron.get_satellite_variable
 
+                # Add global functions for retrieving conventional station reject lists
+                self.env.globals['get_conventional_rejected_stations'] = self.obs_chron.get_conventional_rejected_stations
+
     # ----------------------------------------------------------------------------------------------
 
     def render(self, algorithm):

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -167,7 +167,8 @@ class Renderer():
                 self.env.globals['get_satellite_variable'] = self.obs_chron.get_satellite_variable
 
                 # Add global functions for retrieving conventional station reject lists
-                self.env.globals['get_conventional_rejected_stations'] = self.obs_chron.get_conventional_rejected_stations
+                self.env.globals['get_conventional_rejected_stations'] = \
+                    self.obs_chron.get_conventional_rejected_stations
 
     # ----------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
I forgot a line that is needed to use the conventional chronicle in the rendering of YAMLs