### PR TITLE
Re-set the default number of not_bias_corrected channels

### DIFF
--- a/src/jcb/observation_chronicle/observation_chronicle.py
+++ b/src/jcb/observation_chronicle/observation_chronicle.py
@@ -222,10 +222,10 @@ class ObservationChronicle():
             return ", ".join(str(element) for element in sat_simulated)
         elif variable_name_in == 'not_biascorrtd':
             not_bias_corrected = ", ".join(str(element) for element in channel_not_bias_corrected)
-            # Returns a number -999 if all channels are to be bias-corrected. It keeps UFO from
+            # Returns a number 99999 if all channels are to be bias-corrected. It keeps UFO from
             # skipping bias correction for any channels.
             if not_bias_corrected == "":
-                not_bias_corrected = "-999"
+                not_bias_corrected = "99999"
             return not_bias_corrected
         elif variable_name_in == 'biascorrtd':
             return ", ".join(str(element) for element in channel_bias_corrected)


### PR DESCRIPTION
Per @emilyhcliu 's discovery that the default number of "-999" for not_bias_corrected channels confused UFO weeks ago. The reason is that the dash sign "-" is configured in channels numbers such as "10-20" in UFO, and then wrong channel indices can be returned when "-999" is searched in UFO.  Propose to re-set the default number as "99999".  @emilyhcliu 's tests confirmed that it could fix the issue. 