### PR TITLE
Fail on jinja2 render exception

### DIFF
--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -195,9 +195,8 @@ class Renderer():
         # Render the template hierarchy
         try:
             jedi_dict_yaml = template.render(self.template_dict)
-        except j2.exceptions.UndefinedError as e:
-            print(f'Resolving templates for {algorithm} failed with the following exception: {e}')
-            return None
+        except Exception as e:
+            raise Exception(f'Resolving templates for {algorithm} failed with the following exception: {e}')
 
         # Check that everything was rendered
         jcb.abort_if('{{' in jedi_dict_yaml, f'In template_string_jinja2 '

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -196,7 +196,9 @@ class Renderer():
         try:
             jedi_dict_yaml = template.render(self.template_dict)
         except Exception as e:
-            raise Exception(f'Resolving templates for {algorithm} failed with the following exception: {e}')
+            msg = f'Resolving templates for {algorithm} failed with the following exception: {e}'
+            print(msg)
+            raise Exception(msg)
 
         # Check that everything was rendered
         jcb.abort_if('{{' in jedi_dict_yaml, f'In template_string_jinja2 '


### PR DESCRIPTION
This PR causes jcb to raise an a generic exception if a generic exception is raised by the jinja2 renderer. Currently it causes only a warning to be printed to standard out.

I don't know how many times my testing has failed because the yaml I get rendered has simply "null" in it. I would rather catch the failure at the rendering stage rather than at the point of running a JEDI application with a bad yaml.