### PR TITLE
Preserve exception traceback

### DIFF
--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -196,9 +196,9 @@ class Renderer():
         try:
             jedi_dict_yaml = template.render(self.template_dict)
         except Exception as e:
-            msg = f'Resolving templates for {algorithm} failed with the following exception: {e}'
+            msg = f'Resolving templates for {algorithm} failed with the following exception:\n{e}'
             print(msg)
-            raise Exception(msg)
+            raise Exception(msg) from e
 
         # Check that everything was rendered
         jcb.abort_if('{{' in jedi_dict_yaml, f'In template_string_jinja2 '


### PR DESCRIPTION
This PR ensures that traceback is preserved in the case of a exceptions. It was a suggestion from copilot on https://github.com/NOAA-EMC/jcb/pull/22

See https://github.com/NOAA-EMC/jcb/pull/22#discussion_r2198159325