### PR TITLE
Add Global Jinja2 Function for Observation Engine Creation

### DIFF
--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -32,8 +32,8 @@ def get_nested_dict(nested_dict, keys):
 # --------------------------------------------------------------------------------------------------
 
 
-def get_obs_engine(observation, obs_path, obs_prefix, obs_suffix, script_path=None, 
-        script_input=None):
+def get_obs_engine(observation, obs_path, obs_prefix, obs_suffix, script_path=None,
+                   script_input=None):
     """
     Return obs engine based on if the file exists or not.
     """

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -34,7 +34,7 @@ def get_nested_dict(nested_dict, keys):
 
 def get_obs_engine(observation, obs_path, obs_prefix, obs_suffix, script_path=None, script_input=None):
     """
-    Return obs engine based on if the file is existed or not.
+    Return obs engine based on if the file exists or not.
     """
     filename = os.path.join(obs_path, f"{obs_prefix}{observation}{obs_suffix}")
     obs_engine = dict(type='H5File', obsfile=filename)
@@ -47,9 +47,11 @@ def get_obs_engine(observation, obs_path, obs_prefix, obs_suffix, script_path=No
                 'category': observation.split('_')[-1]
             }
         else:
-            msg = f'{filename} is not existed and either script_path or script_input is' 
-                'not assigned correctly'
-            raise Exception(msg)
+            msg = (
+            f'{filename} does not exist and either script_path or script_input is '
+            'not assigned correctly'
+            )
+            raise FileNotFoundError(msg)
 
     return obs_engine
 

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -32,7 +32,8 @@ def get_nested_dict(nested_dict, keys):
 # --------------------------------------------------------------------------------------------------
 
 
-def get_obs_engine(observation, obs_path, obs_prefix, obs_suffix, script_path=None, script_input=None):
+def get_obs_engine(observation, obs_path, obs_prefix, obs_suffix, script_path=None, 
+        script_input=None):
     """
     Return obs engine based on if the file exists or not.
     """
@@ -48,8 +49,8 @@ def get_obs_engine(observation, obs_path, obs_prefix, obs_suffix, script_path=No
             }
         else:
             msg = (
-            f'{filename} does not exist and either script_path or script_input is '
-            'not assigned correctly'
+                f'{filename} does not exist and either script_path or script_input is '
+                'not assigned correctly'
             )
             raise FileNotFoundError(msg)
 

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -43,7 +43,7 @@ def get_obs_engine(observation, obs_path, obs_prefix, obs_suffix, script_path=No
         if script_path and script_input:
             obs_engine = {
                 'type': 'script',
-                'script file': f'{script_path}bufr_{observation.split("_")[0]}.py',
+                'script file': os.path.join(script_path, f'{observation.split("_")[0]}.py'),
                 'args': {'input': script_input},
                 'category': observation.split('_')[-1]
             }

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -35,7 +35,7 @@ def get_nested_dict(nested_dict, keys):
 def get_obs_engine(observation, obs_path, obs_prefix, obs_suffix, script_path=None,
                    script_input=None):
     """
-    Return obs engine based on if the file exists or not.
+    Return obs engine based on whether the file exists or not.
     """
     filename = os.path.join(obs_path, f"{obs_prefix}{observation}{obs_suffix}")
     obs_engine = dict(type='H5File', obsfile=filename)

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -34,8 +34,7 @@ def get_nested_dict(nested_dict, keys):
 
 def get_obs_engine(observation, obs_path, obs_prefix, obs_suffix, script_path=None, script_input=None):
     """
-    Return True if the file does NOT exist, else False.
-    The file path is constructed as: path/prefix + observation + suffix
+    Return obs engine based on if the file is existed or not.
     """
     filename = os.path.join(obs_path, f"{obs_prefix}{observation}{obs_suffix}")
     obs_engine = dict(type='H5File', obsfile=filename)
@@ -48,7 +47,8 @@ def get_obs_engine(observation, obs_path, obs_prefix, obs_suffix, script_path=No
                 'category': observation.split('_')[-1]
             }
         else:
-            msg = f'{filename} is not existed and either script_path or script_input is not assigned correctly'
+            msg = f'{filename} is not existed and either script_path or script_input is' 
+                'not assigned correctly'
             raise Exception(msg)
 
     return obs_engine

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -32,6 +32,28 @@ def get_nested_dict(nested_dict, keys):
 # --------------------------------------------------------------------------------------------------
 
 
+def get_obs_engine(observation, obs_path, obs_prefix, obs_suffix, script_path=None, script_input=None):
+    """
+    Return True if the file does NOT exist, else False.
+    The file path is constructed as: path/prefix + observation + suffix
+    """
+    filename = os.path.join(obs_path, f"{obs_prefix}{observation}{obs_suffix}")
+    obs_engine = dict(type='H5File', obsfile=filename)
+    if not os.path.exists(filename):
+        if script_path and script_input:
+            obs_engine = {
+                'type': 'script',
+                'script file': f'{script_path}bufr_{observation.split("_")[0]}.py',
+                'args': {'input': script_input},
+                'category': observation.split('_')[-1]
+            }
+        else:
+            msg = f'{filename} is not existed and either script_path or script_input is not assigned correctly'
+            raise Exception(msg)
+
+    return obs_engine
+
+
 class Renderer():
 
     """
@@ -169,6 +191,9 @@ class Renderer():
                 # Add global functions for retrieving conventional station reject lists
                 self.env.globals['get_conventional_rejected_stations'] = \
                     self.obs_chron.get_conventional_rejected_stations
+
+                # Add global functions for testing if the file existed
+                self.env.globals['get_obs_engine'] = get_obs_engine
 
     # ----------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
A global function was created and registered to dynamically generate a section of YAML code based on whether the observation input already exists or needs to be converted directly from the corresponding bufr_d file (reference: https://github.com/NOAA-EMC/spoc/issues/58)