### PR TITLE
Add option to override all filters with a global setting

### DIFF
--- a/jcb_clients.yaml
+++ b/jcb_clients.yaml
@@ -2,6 +2,6 @@ gdas:
   git_url: noaa-emc/jcb-gdas
   git_ref: develop
 
-rdas:
-  git_url: noaa-emc/jcb-rdas
-  git_ref: develop
+#rdas:
+#  git_url: noaa-emc/jcb-rdas
+#  git_ref: develop

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -257,11 +257,7 @@ class Renderer():
                 new_filters = replace_obs_filters_dict.get('override_filters', {})
 
                 # Loop over the observers and replace filters for matching observations
-                for index, observer in enumerate(observers):
-
-                    # Get the obs name based on the list of observations
-                    obs_name = obs_names[index]
-
+                for observer, obs_name in zip(observers, obs_names):
                     # Check whether to replace filters for this observation
                     if obs_name not in obs_to_replace:
                         continue

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -266,9 +266,9 @@ class Renderer():
                     if obs_name not in obs_to_replace:
                         continue
 
-                    # Remove any instance of obs fiters, obs prior filters, obs post filters, obs pre filters
+                    # Remove any instance of filters
                     for filter_key in ['obs filters', 'obs prior filters',
-                                        'obs post filters', 'obs pre filters']:
+                                       'obs post filters', 'obs pre filters']:
                         if filter_key in observer:
                             del observer[filter_key]
 
@@ -315,7 +315,9 @@ class Renderer():
                 f"{obsdatain_filename if obsdatain_filename is not None else 'N/A'}"
             )
 
+
 # --------------------------------------------------------------------------------------------------
+
 
 def render(template_dict: dict):
 

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -250,7 +250,7 @@ class Renderer():
                 # Get list of observations
                 obs_names = self.template_dict['observations']
 
-                # Get list of observations that have their filters replaces
+                # Get list of observations that have their filters replaced
                 obs_to_replace = replace_obs_filters_dict['observations']
 
                 # New filter dictionary

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -256,7 +256,7 @@ class Renderer():
                 # New filter dictionary
                 new_filters = replace_obs_filters_dict.get('override_filters', {})
 
-                # Loop over the observers and remove the non allowable components
+                # Loop over the observers and replace filters for matching observations
                 for index, observer in enumerate(observers):
 
                     # Get the obs name based on the list of observations

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -240,8 +240,45 @@ class Renderer():
                 for key in keys_to_remove:
                     del observer[key]
 
+            # Option to completely override all filters for a list of observations
+            # --------------------------------------------------------------------
+            if 'replace_obs_filters' in self.template_dict:
+
+                # Get dictionary replace_obs_filters
+                replace_obs_filters_dict = self.template_dict['replace_obs_filters']
+
+                # Get list of observations
+                obs_names = self.template_dict['observations']
+
+                # Get list of observations that have their filters replaces
+                obs_to_replace = replace_obs_filters_dict['observations']
+
+                # New filter dictionary
+                new_filters = replace_obs_filters_dict.get('override_filters', {})
+
+                # Loop over the observers and remove the non allowable components
+                for index, observer in enumerate(observers):
+
+                    # Get the obs name based on the list of observations
+                    obs_name = obs_names[index]
+
+                    # Check whether to replace filters for this observation
+                    if obs_name not in obs_to_replace:
+                        continue
+
+                    # Remove any instance of obs fiters, obs prior filters, obs post filters, obs pre filters
+                    for filter_key in ['obs filters', 'obs prior filters',
+                                        'obs post filters', 'obs pre filters']:
+                        if filter_key in observer:
+                            del observer[filter_key]
+
+                    # Set new entry obs filters with the replace dictionary
+                    observer['obs filters'] = new_filters
+
         # Convert the rendered string to a dictionary
         return jedi_dict
+
+# --------------------------------------------------------------------------------------------------
 
     def get_obs_engine(self, observation, component, script_input=None):
         """
@@ -279,7 +316,6 @@ class Renderer():
             )
 
 # --------------------------------------------------------------------------------------------------
-
 
 def render(template_dict: dict):
 


### PR DESCRIPTION
It may be desirable in some cases to have the filters for certain observation types to be completely overwritten with a global setting. For example you could choose to set the QC flags to some predetermined values. This PR add the generic capability to do that.

And example of activating the new option can be seen here: https://github.com/NOAA-EMC/jcb-gdas/compare/feature/override_filters?expand=1