### PR TITLE
Allow 'observation_statistics' as root directory

### DIFF
--- a/test/client_integration/test_client_requirements.py
+++ b/test/client_integration/test_client_requirements.py
@@ -242,6 +242,7 @@ def test_client_allowable_components():
         '.github',
         'model',
         'observations',
+        'observation_statistics',
         'algorithm',
         'observation_chronicle',
         'test',


### PR DESCRIPTION
This PR allows `observation_statistics/` to be a root directory in a JCB client along with `observations/`, `observation_chronicle/`, `model/`, `algorithm/`, etc.  I need an appropriate place to put the `gdas_anlstat` job observation statistics templating YAMLs in`jcb-gdas`, and `model/` is not appropriate, because of its rigid requirements about template variable formatting. These templates behave more like observation templates than model templates. However, `observations/` is not an appropriate location, because it already has YAMLs with the same names as these observation statistics templates. I need an alternative space.