### PR TITLE
Allow JCB apps to be subdirectories of larger repos for GitHub CI purposes

### DIFF
--- a/jcb_client_init.py
+++ b/jcb_client_init.py
@@ -182,10 +182,16 @@ def clone_or_update_repos(jcb_apps: typing.Dict[str, typing.Dict[str, typing.Any
         if app_conf['app_subdir'] == '':
             clone_path = target_path
         else:
-            clone_path = target_path + '_parent_repo'
+            # Get the path of this file
+            file_path = os.path.dirname(os.path.realpath(__file__))
+
+            # Set the path to where the applications will be cloned
+            jcb_config_path = os.path.join(file_path, 'src', 'jcb', 'configuration')
+
+            clone_path = os.path.join(jcb_config_path, f"{app}_parent_repo")
 
         # Check if the target path exists
-        if not os.path.exists(target_path):
+        if not os.path.exists(clone_path):
 
             # Clone command
             full_url = f'https://github.com/{app_conf["git_url"]}.git'
@@ -198,7 +204,7 @@ def clone_or_update_repos(jcb_apps: typing.Dict[str, typing.Dict[str, typing.Any
             subprocess.run(git_clone, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
             if app_conf['app_subdir'] != '':
-                copy = ['cp', '-r', os.path.join(clone_path, app_conf['app_subdir']), target_path]
+                copy = ['cp', '-rf', os.path.join(clone_path, app_conf['app_subdir']), target_path]
 
                 # Copy the subdirectory to the target path
                 command_string = ' '.join(copy)

--- a/jcb_client_init.py
+++ b/jcb_client_init.py
@@ -179,6 +179,10 @@ def clone_or_update_repos(jcb_apps: typing.Dict[str, typing.Dict[str, typing.Any
     for app, app_conf in jcb_apps.items():
 
         target_path = app_conf['target_path']
+        if app_config['app_subdir'] == '':
+            clone_path = target_path
+        else:
+            clone_path = target_path + '_temp'
 
         # Check if the target path exists
         if not os.path.exists(target_path):
@@ -186,12 +190,20 @@ def clone_or_update_repos(jcb_apps: typing.Dict[str, typing.Dict[str, typing.Any
             # Clone command
             full_url = f'https://github.com/{app_conf["git_url"]}.git'
             git_clone = ['git', 'clone', full_url, '-b', app_conf['git_ref'],
-                         target_path]
+                         clone_path]
 
             # Clone the repository
             command_string = ' '.join(git_clone)
             write_message(f'Cloning {app} with command: {command_string}')
             subprocess.run(git_clone, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+            if app_conf['app_subdir'] != '':
+                copy = ['cp', '-r', os.path.join(clone_path, app_conf['app_subdir']), target_path]
+
+                # Copy the subdirectory to the target path
+                command_string = ' '.join(copy)
+                write_message(f'Copying {app} subdirectory with command: {command_string}')
+                subprocess.run(copy, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
         else:
 
@@ -254,7 +266,7 @@ if __name__ == "__main__":
 
     # Link all the application test YAML files to client_integration test directory
     for app, app_conf in jcb_apps.items():
-        test_path = os.path.join(app_conf['target_path'], app_conf['app_subdir'], 'test', 'client_integration')
+        test_path = os.path.join(app_conf['target_path'], 'test', 'client_integration')
         if not os.path.exists(test_path):
             continue
         yaml_files = [f for f in os.listdir(test_path) if f.endswith('.yaml')]

--- a/jcb_client_init.py
+++ b/jcb_client_init.py
@@ -179,10 +179,10 @@ def clone_or_update_repos(jcb_apps: typing.Dict[str, typing.Dict[str, typing.Any
     for app, app_conf in jcb_apps.items():
 
         target_path = app_conf['target_path']
-        if app_config['app_subdir'] == '':
+        if app_conf['app_subdir'] == '':
             clone_path = target_path
         else:
-            clone_path = target_path + '_temp'
+            clone_path = target_path + '_parent_repo'
 
         # Check if the target path exists
         if not os.path.exists(target_path):

--- a/jcb_client_init.py
+++ b/jcb_client_init.py
@@ -180,8 +180,11 @@ def clone_or_update_repos(jcb_apps: typing.Dict[str, typing.Dict[str, typing.Any
 
         target_path = app_conf['target_path']
         if app_conf['app_subdir'] == '':
+            # If jcb app is its own repo, clone directly to target path
             clone_path = target_path
         else:
+            # if jcb app is a subdirectory of a larger repo, clone to a temp location first
+
             # Get the path of this file
             file_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -203,6 +206,7 @@ def clone_or_update_repos(jcb_apps: typing.Dict[str, typing.Dict[str, typing.Any
             write_message(f'Cloning {app} with command: {command_string}')
             subprocess.run(git_clone, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
+            # If app_subdir is set, copy the jcb app subdirectory to the target path
             if app_conf['app_subdir'] != '':
                 copy = ['cp', '-rf', os.path.join(clone_path, app_conf['app_subdir']), target_path]
 

--- a/jcb_client_init.py
+++ b/jcb_client_init.py
@@ -5,6 +5,7 @@
 
 
 import os
+import shutil
 import subprocess
 import typing
 

--- a/jcb_client_init.py
+++ b/jcb_client_init.py
@@ -188,7 +188,7 @@ def clone_or_update_repos(jcb_apps: typing.Dict[str, typing.Dict[str, typing.Any
             # Get the path of this file
             file_path = os.path.dirname(os.path.realpath(__file__))
 
-            # Set the path to where the applications will be cloned
+            # Set the path to where the parent repos will be cloned
             jcb_config_path = os.path.join(file_path, 'src', 'jcb', 'configuration')
 
             clone_path = os.path.join(jcb_config_path, f"{app}_parent_repo")

--- a/jcb_client_init.py
+++ b/jcb_client_init.py
@@ -234,13 +234,16 @@ if __name__ == "__main__":
         for key in required_keys:
             if key not in app_conf:
                 raise Exception(f'Key \'{key}\' not found in jcb_apps.yaml')
+        if 'app_subdir' not in app_conf:
+            app_conf['app_subdir'] = ''
         app_conf['target_path'] = os.path.join(jcb_config_path, 'apps', app)
 
     # Add jcb-algorithms to the dictionary
     jcb_apps['algorithms'] = {
         'git_url': 'noaa-emc/jcb-algorithms',
         'git_ref': 'develop',
-        'target_path': os.path.join(jcb_config_path, 'algorithms')
+        'app_subdir': '',
+        'target_path': os.path.join(jcb_config_path, 'algorithms'),
     }
 
     # Update the default refs for the clients
@@ -251,7 +254,7 @@ if __name__ == "__main__":
 
     # Link all the application test YAML files to client_integration test directory
     for app, app_conf in jcb_apps.items():
-        test_path = os.path.join(app_conf['target_path'], 'test', 'client_integration')
+        test_path = os.path.join(app_conf['target_path'], app_conf['app_subdir'], 'test', 'client_integration')
         if not os.path.exists(test_path):
             continue
         yaml_files = [f for f in os.listdir(test_path) if f.endswith('.yaml')]

--- a/jcb_client_init.py
+++ b/jcb_client_init.py
@@ -208,13 +208,11 @@ def clone_or_update_repos(jcb_apps: typing.Dict[str, typing.Dict[str, typing.Any
 
             # If app_subdir is set, copy the jcb app subdirectory to the target path
             if app_conf['app_subdir'] != '':
-                copy = ['cp', '-rf', os.path.join(clone_path, app_conf['app_subdir']), target_path]
-
-                # Copy the subdirectory to the target path
-                command_string = ' '.join(copy)
-                write_message(f'Copying {app} subdirectory with command: {command_string}')
-                subprocess.run(copy, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-
+                shutil.copytree(
+                    os.path.join(clone_path, app_conf['app_subdir']),
+                    target_path,
+                    dirs_exist_ok=True  # Python 3.8+
+                )
         else:
 
             # Print warning that repo is already cloned


### PR DESCRIPTION
This PR modifies JCB client integration testing to allow for JCB apps to be subdirectories of larger repositories rather than stand-alone repositories. This will allow the merger of `jcb-gdas` into `gdasapp` while moving JCB client integration testing into the `gdasapp` repo on GitHub.

A new optional key, 'app_subdir', is now permitted in `jcb_clients.yaml` that indicates the relative path of the JCB app in its parent repo.

I tested these changes in two ways:
1. I created a `jcb-gdas` PR, https://github.com/NOAA-EMC/jcb-gdas/pull/226 , setting the `jcb` repo branch for GitHub CI testing to this branch. GitHub CI passes successfully.
2. I created a `gdasapp` PR, https://github.com/NOAA-EMC/GDASApp/pull/2031, that merged `jcb-gdas` into `gdasapp` as a subdirectory of that repo, and with the GitHub CI workflows for `jcb-gdas` into `gdasapp`. Again, I set the jcb` repo branch for GitHub CI testing to this branch, and it passes CI successly.