### PR TITLE
Output station IDs in reject list as strings

### DIFF
--- a/src/jcb/observation_chronicle/conv_chronicle.py
+++ b/src/jcb/observation_chronicle/conv_chronicle.py
@@ -9,9 +9,9 @@ import yaml
 
 
 """
-We need the output yaml to have quote marks on stationIDS. PyYAML will only use
-quotes on strings that it deems un-ambiguous values.
-Add stationID method and representer to force use of quotes.
+We need the output YAML to include quote marks around station IDs. PyYAML will only use
+quotes for strings that it deems unambiguous values.
+Add a StationID subclass and representer to force the use of quotes.
 """
 # --------------------------------------------------------------------------------------------------
 class StationID(str):
@@ -25,6 +25,22 @@ def _stationid_representer(dumper, data):
         style="'")
 
 yaml.SafeDumper.add_representer(StationID, _stationid_representer)
+
+
+def test_station_id_yaml_emission_uses_quoted_strings():
+    """Regression test: StationID values must be emitted with quotes by the CLI dumper."""
+    document = {
+        'station_reject_list': [
+            StationID('00123'),
+            StationID('ABC'),
+        ]
+    }
+
+    dumped = yaml.dump(document, Dumper=yaml.SafeDumper, sort_keys=False)
+
+    assert "station_reject_list:" in dumped
+    assert "- '00123'" in dumped
+    assert "- 'ABC'" in dumped
 yaml.Dumper.add_representer(StationID, _stationid_representer)
 # --------------------------------------------------------------------------------------------------
 

--- a/src/jcb/observation_chronicle/conv_chronicle.py
+++ b/src/jcb/observation_chronicle/conv_chronicle.py
@@ -29,6 +29,7 @@ def _stationid_representer(dumper, data):
 
 
 yaml.SafeDumper.add_representer(StationID, _stationid_representer)
+yaml.Dumper.add_representer(StationID, _stationid_representer)
 
 
 def test_station_id_yaml_emission_uses_quoted_strings():
@@ -45,7 +46,6 @@ def test_station_id_yaml_emission_uses_quoted_strings():
     assert "station_reject_list:" in dumped
     assert "- '01001'" in dumped
     assert "- '01008'" in dumped
-yaml.Dumper.add_representer(StationID, _stationid_representer)
 
 
 # --------------------------------------------------------------------------------------------------

--- a/src/jcb/observation_chronicle/conv_chronicle.py
+++ b/src/jcb/observation_chronicle/conv_chronicle.py
@@ -5,8 +5,26 @@ import copy
 from datetime import datetime
 
 import jcb
+import yaml
 
 
+"""
+We need the output yaml to have quote marks on stationIDS. PyYAML will only use
+quotes on strings that it deems un-ambiguous values.
+Add stationID method and representer to force use of quotes.
+"""
+# --------------------------------------------------------------------------------------------------
+class StationID(str):
+    """Str subclass to force PyYAML to retain/write out as strings."""
+    pass
+
+def _stationid_representer(dumper, data):
+    return dumper.represent_scalar(
+        yaml.resolver.BaseResolver.DEFAULT_SCALAR_TAG,
+        str(data),
+        style="'")
+
+yaml.SafeDumper.add_representer(StationID, _stationid_representer)
 # --------------------------------------------------------------------------------------------------
 
 """
@@ -24,7 +42,6 @@ function_map = {
     'min': min,
     'max': max,
 }
-
 
 # --------------------------------------------------------------------------------------------------
 
@@ -121,7 +138,6 @@ def process_station_chronicles(ob_type, window_begin, window_final, chronicle_in
         The function assumes that the station IDs are properly structured
         in the input `chronicle` dictionary.
     """
-
     # Copy the incoming chronicle to avoid modifying the original
     # -----------------------------------------------------------
     chronicle = copy.deepcopy(chronicle_in)
@@ -155,8 +171,7 @@ def process_station_chronicles(ob_type, window_begin, window_final, chronicle_in
 
     # Initial list of stations to reject
     # ----------------------------------
-    station_reject_list = chronicle.get('stations_to_reject')
-
+    station_reject_list = [StationID(s) for s in chronicle.get('stations_to_reject') or []]
     # Store chronicle at the initial commissioned date
     add_to_evolving_observing_system(evolving_observing_system, commissioned, station_reject_list)
 
@@ -193,12 +208,12 @@ def process_station_chronicles(ob_type, window_begin, window_final, chronicle_in
 
         # If the chronicle has key add_to_reject_list
         if 'add_to_reject_list' in chronicle:
-            add_list = chronicle['add_to_reject_list']
+            add_list = [StationID(s) for s in chronicle['add_to_reject_list']]
             station_reject_list = station_reject_list + add_list
 
         # If the chronicle has key remove_from_reject_list
         if 'remove_from_reject_list' in chronicle:
-            remove_list = chronicle['remove_from_reject_list']
+            remove_list = [StationID(s) for s in chronicle['remove_from_reject_list']]
             station_reject_list = [item for item in station_reject_list if item not in remove_list]
 
         # If the chronicle has key revert_to_previous_chronicle

--- a/src/jcb/observation_chronicle/conv_chronicle.py
+++ b/src/jcb/observation_chronicle/conv_chronicle.py
@@ -14,15 +14,19 @@ quotes for strings that it deems unambiguous values.
 Add a StationID subclass and representer to force the use of quotes.
 """
 # --------------------------------------------------------------------------------------------------
+
+
 class StationID(str):
     """Str subclass to force PyYAML to retain/write out as strings."""
     pass
+
 
 def _stationid_representer(dumper, data):
     return dumper.represent_scalar(
         yaml.resolver.BaseResolver.DEFAULT_SCALAR_TAG,
         str(data),
         style="'")
+
 
 yaml.SafeDumper.add_representer(StationID, _stationid_representer)
 
@@ -31,16 +35,16 @@ def test_station_id_yaml_emission_uses_quoted_strings():
     """Regression test: StationID values must be emitted with quotes by the CLI dumper."""
     document = {
         'station_reject_list': [
-            StationID('00123'),
-            StationID('ABC'),
+            StationID('01001'),
+            StationID('01008'),
         ]
     }
 
     dumped = yaml.dump(document, Dumper=yaml.SafeDumper, sort_keys=False)
 
     assert "station_reject_list:" in dumped
-    assert "- '00123'" in dumped
-    assert "- 'ABC'" in dumped
+    assert "- '01001'" in dumped
+    assert "- '01008'" in dumped
 yaml.Dumper.add_representer(StationID, _stationid_representer)
 # --------------------------------------------------------------------------------------------------
 

--- a/src/jcb/observation_chronicle/conv_chronicle.py
+++ b/src/jcb/observation_chronicle/conv_chronicle.py
@@ -46,6 +46,8 @@ def test_station_id_yaml_emission_uses_quoted_strings():
     assert "- '01001'" in dumped
     assert "- '01008'" in dumped
 yaml.Dumper.add_representer(StationID, _stationid_representer)
+
+
 # --------------------------------------------------------------------------------------------------
 
 """

--- a/src/jcb/observation_chronicle/conv_chronicle.py
+++ b/src/jcb/observation_chronicle/conv_chronicle.py
@@ -25,6 +25,7 @@ def _stationid_representer(dumper, data):
         style="'")
 
 yaml.SafeDumper.add_representer(StationID, _stationid_representer)
+yaml.Dumper.add_representer(StationID, _stationid_representer)
 # --------------------------------------------------------------------------------------------------
 
 """

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -335,7 +335,6 @@ class Renderer():
                     print('         currently not implemented in jcb for this application')
                     print('         (only foratmoshere now).')
 
-
         _retype_station_id_lists(jedi_dict)
 
         # Convert the rendered string to a dictionary

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -6,7 +6,6 @@ import os
 import jcb
 import jinja2 as j2
 import yaml
-
 from jcb.observation_chronicle.conv_chronicle import StationID
 
 

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -7,6 +7,8 @@ import jcb
 import jinja2 as j2
 import yaml
 
+from jcb.observation_chronicle.conv_chronicle import StationID
+
 
 # --------------------------------------------------------------------------------------------------
 
@@ -27,6 +29,26 @@ def get_nested_dict(nested_dict, keys):
     for key in keys:
         nested_dict = nested_dict[key]  # Navigate deeper into the dictionary
     return nested_dict
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+def _retype_station_id_lists(obj):
+    """
+    Re-type stations in reject lost to StationID type, as type is lost somewhere along the way.
+    """
+    if isinstance(obj, dict):
+        if (isinstance(obj.get('variable'), dict)
+                and obj['variable'].get('name') == 'MetaData/stationIdentification'
+                and isinstance(obj.get('is_in'), list)):
+            obj['is_in'] = [StationID(s) if isinstance(s, str) else s
+                            for s in obj['is_in']]
+        for v in obj.values():
+            _retype_station_id_lists(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            _retype_station_id_lists(item)
 
 
 # --------------------------------------------------------------------------------------------------
@@ -315,6 +337,9 @@ class Renderer():
                     print('WARNING: obs_distribution_localizations in local_ensemble_da is')
                     print('         currently not implemented in jcb for this application')
                     print('         (only foratmoshere now).')
+
+
+        _retype_station_id_lists(jedi_dict)
 
         # Convert the rendered string to a dictionary
         return jedi_dict

--- a/src/jcb/renderer.py
+++ b/src/jcb/renderer.py
@@ -36,7 +36,7 @@ def get_nested_dict(nested_dict, keys):
 
 def _retype_station_id_lists(obj):
     """
-    Re-type stations in reject lost to StationID type, as type is lost somewhere along the way.
+    Re-type stations in reject list to StationID type, as type is lost somewhere along the way.
     """
     if isinstance(obj, dict):
         if (isinstance(obj.get('variable'), dict)


### PR DESCRIPTION
Added a stationID data type to force outputting station IDS with quotation marks. 

With these changes the output yaml has quotation marks around all reject list stations, and the analysis then correctly discards all the stations. 

Addresses jcb-gdas issue [234](https://github.com/NOAA-EMC/jcb-gdas/issues/234)